### PR TITLE
Run mypy on every version, exclude python version 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ cache:
   directories: [$HOME/.cache/pre-commit]
 matrix:
   include:
-  - python: '3.5'
   - python: '3.6'
   - python: '3.7'
   - python: '3.8'
-    env: PRE_COMMIT=1 MYPY=1
+    env: PRE_COMMIT=1
   fast_finish: true
 dist: xenial
 sudo: true
@@ -16,12 +15,12 @@ sudo: true
 install:
 - pip install coverage coveralls
 - test ! "$PRE_COMMIT" || pip install pre-commit
-- test ! "$MYPY" || pip install "mypy>=0.782"
+- pip install "mypy>=0.782"
 - pip install -e .
 
 script:
 - test ! "$PRE_COMMIT" || pre-commit run --all-files
-- test ! "$MYPY" || mypy pysyncthru
+- mypy --python-version $TRAVIS_PYTHON_VERSION pysyncthru
 - coverage run --source=pysyncthru setup.py test
 
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Object Brokering",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
aiohttp is not compatible with python versions below 3.6
This exposes another issue of the previous configuration: for some reason mypy did not check for the currently running python version only but for all of them. Now, each time mypy runs only for the currently installed version