### PR TITLE
Do not explicitly specify the python version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [mypy]
-python_version = 3.5
 follow_imports = silent
 ignore_missing_imports = true
 strict = true


### PR DESCRIPTION
Rather, each version of python that is officially supported runs its own test