### PR TITLE
Remove unescaped line termination characters from string literals if needed

### DIFF
--- a/pysyncthru/__init__.py
+++ b/pysyncthru/__init__.py
@@ -80,7 +80,6 @@ class SyncThru:
             try:
                 async with self._session.get(url) as response:
                     json_data = await response.text()
-                    print(json_data)
                 
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 json_data = ''


### PR DESCRIPTION
If the printer isn't sleeping then the `status1` field frequently contains unescaped new line characters which causes the `demjson3` to generate an exception.

This PR attempts to escape these new line characters if the initial parsing fails before trying to reparse the json.